### PR TITLE
* corrige geração de documentos inválidos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
-  - hhvm
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
 
 before_script:
   - travis_retry composer self-update

--- a/src/FakerBR.php
+++ b/src/FakerBR.php
@@ -42,10 +42,10 @@ class FakerBR extends Base
 
         $d2= 11 - ($total % 11);
 
-        $cnpj .= ($d2 >= 10)?'0':$d2;
-
-        if(!$verdadeiro)
-            return self::shuffleString($cnpj);
+        if($verdadeiro)
+            $cnpj .= ($d2 >= 10)?'0':$d2;
+        else
+            $cnpj .= ($d2 >= 9)?'1':$d2+1;
 
         return $cnpj;
     }
@@ -78,10 +78,10 @@ class FakerBR extends Base
 
         $d2= 11 - ($total % 11);
 
-        $cpf .= ($d2 >= 10)?'0':$d2;
-
-        if(!$verdadeiro)
-            $cpf = self::shuffleString($cpf);
+        if($verdadeiro)
+            $cpf .= ($d2 >= 10)?'0':$d2;
+        else
+            $cpf .= ($d2 >= 9)?'1':$d2+1;
 
         if($formatado)
             $cpf = Utils::mask($cpf, Mask::CPF);

--- a/tests/FakerBRTest.php
+++ b/tests/FakerBRTest.php
@@ -12,7 +12,6 @@ class FakerBRTest extends PHPUnit_Framework_TestCase {
 
         $faker = Factory::create();
         $faker->addProvider(new FakerBR($faker));
-echo $faker->cnpj; die;
         $this->assertTrue(Utils::isCnpj($faker->cnpj));
         $this->assertTrue(Utils::isCpf($faker->cpf));
     }


### PR DESCRIPTION
* alterado `.travis-ci.yml` para testar apenas nas versões suportadas atualmente do PHP e Composer;
* habilitado o phpunit para permitir os testes (removida linha que encerrava os testes);
* corrigida geração de documentos inválidos

Em algumas ocasiões a geração de documento inválido estava gerando documentos válidos, tanto para cpf quando para cnpj, a execução em loop dos testes depois de algumas tentativas acabava gerando um documento que passava pelo `isCnpj` e `isCpf` portanto causava a saída dos testes, isso ocorre porque estava sendo simplesmente embaralhado o número gerado, correndo um risco do número embaralhado ser válido (chances de 1:100 se considerar todos os dígidos, mas ocorria com maior frequência para cpf do que para cnpj).

A correção apenas altera o último dígito adicionando 1 a ele quando solicitado para gerar documento inválido, garantindo que o documento não passará pelo teste.
